### PR TITLE
Removes Pex from IsUnitTestRunner

### DIFF
--- a/Splat/PlatformModeDetector.cs
+++ b/Splat/PlatformModeDetector.cs
@@ -22,7 +22,6 @@ namespace Splat
                 "NUNIT",
                 "XUNIT",
                 "MBUNIT",
-                "PEX.",
                 "NBEHAVE",
             };
 


### PR DESCRIPTION
I was getting a false positive since I had a reference to WriteableBitampEx.WinRt.

I was under the impression that I had removed this before in the ReactiveUI project...