### PR TITLE
.NET 4.5 Fix for MethodNotFoundException when constructing a System.Drawing.Color using a KnownColor

### DIFF
--- a/Splat/TypeForwardedSystemDrawing.cs
+++ b/Splat/TypeForwardedSystemDrawing.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 
 #if !UIKIT
 [assembly: TypeForwardedTo(typeof(Color))]
+[assembly: TypeForwardedTo(typeof(KnownColor))]
 #endif
 
 [assembly: TypeForwardedTo(typeof(Point))]


### PR DESCRIPTION
I think this is in the right place in the #ifdef