### PR TITLE
Marked up System.Drawing.Color as a DataContract so that it can be serialized

### DIFF
--- a/Splat/Colors/Color.cs
+++ b/Splat/Colors/Color.cs
@@ -35,9 +35,11 @@
 
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
 
 namespace System.Drawing
 {
+    [DataContract]
     public struct Color
     {
 
@@ -137,6 +139,7 @@ namespace System.Drawing
             }
         }
 
+        [DataMember]
         internal long Value
         {
             get


### PR DESCRIPTION
For System.Drawing.Color to be useful cross platform, I need to be able to persist instances in my mobile app.

This works OK in my .NET 4.5 unit tests because System.Drawing.Color is redirected to the .NET framework version. On Windows phone however the Splat implementation is used, which doesn't have the appropriate mark up to allow serialization. I've added DataContract markup, which allows the value property to serialize correctly. The Color Name does not serialize, because it only gets populated when using the constructor that takes a KnownColor of a known name. I don't think this really matters though, as it is the value that is the important piece of data.