### PR TITLE
Hide IEnableLogger from COM to allow ComVisible-classes to still log with Splat

### DIFF
--- a/Splat/Logging.cs
+++ b/Splat/Logging.cs
@@ -175,6 +175,7 @@ namespace Splat
     /// Mixin, which will give you a Logger that includes the class name in the
     /// log.
     /// </summary>
+    [System.Runtime.InteropServices.ComVisible(false)]
     public interface IEnableLogger { }
 
     public static class LogHost


### PR DESCRIPTION
Hey Paul,

First ever github PR.  Just going to guess how this works, let me know what all I screwed up... I'll catch on quick.

I'm using Splat in a project. The project includes an exported COM object to implement IDTExtensibility2 blahblahblah Office blahblahblah COM. Ran into the issue that if I "implement" IEnableLogger on that exposed COM object itself, the typelib converter gets mad that Splat isn't registered with COM:
> :x: 3 The assembly 'Splat, Version=1.6.1.0, Culture=neutral, PublicKeyToken=null' is not registered for COM Interop. Please register it with regasm.exe /tlb.
> :x: 4 The assembly "D:\Projects\foo\bin\Local Debug\bar.dll" could not be converted to a type library. Type library exporter encountered an error while processing 'Baz.Connect, Baz'. Error: Error loading type library/DLL.

I don't think anybody *wants* Splat registered with COM... True?

So, this PR appears to be one valid way to tell the typelib converter "These are not the IDroids you're looking for."  Not sure if that's the Right Way :tm: but it makes my local compile happy.

Thoughts?