### PR TITLE
Generic mixins for IMutableDependencyResolver register functions

### DIFF
--- a/Splat/ServiceLocation.cs
+++ b/Splat/ServiceLocation.cs
@@ -180,16 +180,31 @@ namespace Splat
 
             return new ActionDisposable(() => Locator.Current = origResolver);
         }
+
+        public static void Register<T>(this IMutableDependencyResolver This, Func<object> factory, string contract = null)
+        {
+            This.Register(factory, typeof(T), contract);
+        }
                 
         public static void RegisterConstant(this IMutableDependencyResolver This, object value, Type serviceType, string contract = null)
         {
             This.Register(() => value, serviceType, contract);
         }
 
+        public static void RegisterConstant<T>(this IMutableDependencyResolver This, object value, string contract = null)
+        {
+            RegisterConstant(This, value, typeof(T), contract);
+        }
+
         public static void RegisterLazySingleton(this IMutableDependencyResolver This, Func<object> valueFactory, Type serviceType, string contract = null)
         {
             var val = new Lazy<object>(valueFactory, LazyThreadSafetyMode.ExecutionAndPublication);
             This.Register(() => val.Value, serviceType, contract);
+        }
+
+        public static void RegisterLazySingleton<T>(this IMutableDependencyResolver This, Func<object> valueFactory, string contract = null)
+        {
+            RegisterLazySingleton(This, valueFactory, typeof(T), contract);
         }
 
         public static void InitializeSplat(this IMutableDependencyResolver This)


### PR DESCRIPTION
adding three generic mixins for `Register`, `RegisterConstant`, and `RegisterLazySingleton`. These mixins allow registration based on a generic type parameter rather than using `typeof(...)` as a `serviceType` parameter.

```csharp
// Example usage
public class AppBootstrapper : ReactiveObject, IScreen
{
    public AppBootstrapper()
    {
        // old method
        // dependencyResolver.RegisterConstant(this, typeof(IScreen));

        // new method
        dependencyResolver.RegisterConstant<IScreen>(this);
    }
}
```

New mixin functions simply call their non-generic mixin counterparts, except for `Register` which is not a mixin to begin with.