### PR TITLE
Attempt to fix #117 (Xam.Mac Unified w/o dependency on System.Drawing)

### DIFF
--- a/Splat/Cocoa/Bitmaps.cs
+++ b/Splat/Cocoa/Bitmaps.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Drawing;
 
 #if UIKIT && !UNIFIED
 using MonoTouch.UIKit;
@@ -17,6 +16,7 @@ using Foundation;
 using UIImage = AppKit.NSImage;
 using UIApplication = AppKit.NSApplication;
 #else
+using System.Drawing;
 using MonoMac.AppKit;
 using MonoMac.Foundation;
 

--- a/Splat/Splat-XamarinMac.csproj
+++ b/Splat/Splat-XamarinMac.csproj
@@ -67,6 +67,9 @@
     <Compile Include="SizeExtensions.cs" />
     <Compile Include="Logging.cs" />
     <Compile Include="MemoizingMRUCache.cs" />
+    <Compile Include="Colors\Color.cs" />
+    <Compile Include="Colors\KnownColor.cs" />
+    <Compile Include="Colors\KnownColors.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>


### PR DESCRIPTION
This PR fixes the Xamarin.Mac project so it builds. I also confirmed that mono touch still builds. Don't have a Xam.iOS license, so can't be 100% certain I didn't mess that one up.