### PR TITLE
Enable also relative URI in Xaml Bitmap PlatformBitmapLoader.LoadFromResource

### DIFF
--- a/Splat/Xaml/Bitmaps.cs
+++ b/Splat/Xaml/Bitmaps.cs
@@ -54,7 +54,7 @@ namespace Splat
                         x.DecodePixelHeight = (int)desiredHeight;
                     }
 
-                    x.UriSource = new Uri(resource);
+                    x.UriSource = new Uri(resource, UriKind.RelativeOrAbsolute);
                 });
 
                 return (IBitmap) new BitmapSourceBitmap(ret);


### PR DESCRIPTION
System.Uri constructor without UriKind parameter creates a UriKind.Absolute Uri but local bitmap resources may require a Uri of type UriKind.Relative. Thus adding the UriKind.RelativeOrAbsolute parameter in Xaml version of PlatformBitmapLoader.LoadFromResource.

I couldn't get the function to work with embedded resources on WP8 app without this modification.